### PR TITLE
Schema property _inviewThreshold needs to be a number

### DIFF
--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -23,8 +23,7 @@
               "type": "number",
               "title": "Inview threshold",
               "description": "The percentage amount required onscreen before playing.",
-              "default": 80,
-              "_backboneForms": "Text"
+              "default": 80
             }
           }
         }


### PR DESCRIPTION
### Fix

- Schema property _inviewThreshold in course.schema.json changed from string to number. 


